### PR TITLE
Fix paypal txn id can't be nil

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -18,8 +18,7 @@ class Payment
   field :txn_type
   field :test, type: Boolean
 
-  validates :txn_id, presence: true
-  validates :txn_id, uniqueness: true
+  validates :txn_id, uniqueness: true, :allow_blank => true, :allow_nil => true
 
   private
   def configure_subscription_status

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Payment, type: :model do
 
   describe "ActiveModel validations" do
     it { is_expected.to belong_to(:member) }
-    it { is_expected.to validate_presence_of(:txn_id) }
     it { is_expected.to validate_uniqueness_of(:txn_id) }
   end
 


### PR DESCRIPTION
Paypal is a bunch of liars.  They said all IPNs should be checked for a unique txn id to verify that it is not a dupe, but then they don't send txn_ids for all types of txns, namely subscription status changes.  So this fix is to still save those status changes while still checking for dupe txn ids