### PR TITLE
fix signature bug

### DIFF
--- a/Docker/Dockerfiles/dev
+++ b/Docker/Dockerfiles/dev
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6.1
 
 # Install base packages
 RUN curl -sL https://deb.nodesource.com/setup_8.x  | bash -

--- a/Docker/Dockerfiles/tester
+++ b/Docker/Dockerfiles/tester
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6.1
 
 # Install base packages
 RUN curl -sL https://deb.nodesource.com/setup_8.x  | bash -

--- a/Docker/Dockerfiles/webpack
+++ b/Docker/Dockerfiles/webpack
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6.1
 
 # Install base packages
 RUN curl -sL https://deb.nodesource.com/setup_8.x  | bash -

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -26,7 +26,8 @@ class MembersController < ApplicationController
 
       if signature_params[:signature]
         begin
-          upload_signature(signature_params[:signature], "#{@member.fullname}_signature.png")
+          encoded_img = signature_params[:signature].split(",")[1]
+          upload_signature(encoded_img, "#{@member.fullname}_signature.png")
           @member.update_attributes!(memberContractOnFile: true)
         rescue Error::Google::Upload => err
           @messages.push("Error uploading #{@member.fullname}'s signature'. Error: #{err}")


### PR DESCRIPTION
Signature data was being uploaded but wasn't correctly parsed beforehand so Google was failing to render it.  Basically we could get the images if we parsed them afterwards but couldn't view them online.

This parses the base64 data before sending it to Google so we'll see the rendered images of the signatures.