### PR TITLE
normalize how exp times are stored

### DIFF
--- a/app/models/concerns/invoiceable_resource.rb
+++ b/app/models/concerns/invoiceable_resource.rb
@@ -16,5 +16,40 @@ module InvoiceableResource
       end
       self.update_expiration((newExpTime.to_i * 1000))
     end
+
+    def prettyTime
+      if self.get_expiration
+        return self.expiration_as_time
+      else
+        return Time.at(0)
+      end
+    end
+
+    def get_expiration
+      self[self.expiration_attr]
+    end
+
+    protected
+    def update_expiration(new_expiration)
+      self.update_attributes!(self.expiration_attr => expiration_as_ms(new_expiration))
+    end
+
+    def expiration_as_time(ms = nil)
+      exp ||= self.get_expiration
+      if exp.is_a? Numeric
+        return Time.at(exp/1000)
+      else
+        return Time.parse(exp.to_s)
+      end
+    end
+
+    def expiration_as_ms(exp = nil)
+      exp ||= self.get_expiration
+      if exp.is_a? Numeric
+        return exp
+      else
+        return Time.parse(exp.to_s).to_i * 1000
+      end
+    end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -76,14 +76,6 @@ class Member
     return "#{self.firstname} #{self.lastname}"
   end
 
-   def prettyTime
-     if self.expirationTime
-       return Time.at(self.expirationTime/1000)
-     else
-       return Time.at(0)
-     end
-   end
-
   def verify_group_expiry
     if self.group
       #make sure member benefits from group expTime
@@ -139,14 +131,6 @@ class Member
 
   def expiration_attr
     :expirationTime
-  end
-
-  def update_expiration(new_expiration)
-    self.update_attributes!(self.expiration_attr => new_expiration)
-  end
-
-  def get_expiration
-    self.expirationTime
   end
 
   private

--- a/app/models/rental.rb
+++ b/app/models/rental.rb
@@ -7,22 +7,10 @@ class Rental
 
   field :number
   field :description
-  field :expiration
+  field :expiration, type: Integer
   field :subscription_id, type: String # Braintree relation
 
   validates :number, presence: true, uniqueness: true
-
-  def prettyTime
-    if self.expiration
-      return self.expiration_as_time
-    else
-      return Time.at(0)
-    end
-  end
-
-  def get_expiration(exp = nil)
-    self.expiration_as_ms(exp)
-  end
 
   protected
   def remove_subscription
@@ -31,27 +19,5 @@ class Rental
 
   def expiration_attr
     :expiration
-  end
-
-  def update_expiration(new_expiration)
-    self.update_attributes!(self.expiration_attr => get_expiration(new_expiration))
-  end
-
-  def expiration_as_time(ms = nil)
-    exp ||= self.expiration
-    if exp.is_a? Numeric
-      return Time.at(exp/1000)
-    else
-      return Time.parse(exp.to_s)
-    end
-  end
-
-  def expiration_as_ms(exp = nil)
-    exp ||= self.expiration
-    if exp.is_a? Numeric
-      return exp
-    else
-      return exp.to_i * 1000
-    end
   end
 end

--- a/spec/controllers/admin/rentals_controller_spec.rb
+++ b/spec/controllers/admin/rentals_controller_spec.rb
@@ -63,14 +63,14 @@ RSpec.describe Admin::RentalsController, type: :controller do
     context "with valid params" do
       let(:new_attributes) {
         {
-          expiration: (Time.now + 2.months)
+          expiration: (Time.now + 2.months).to_i * 1000
         }
       }
       it "updates the requested rental" do
         rental = Rental.create(valid_attributes)
         put :update, params: {id: rental.to_param, rental: new_attributes}, format: :json
         rental.reload
-        expect(rental.prettyTime).to eq(Time.parse(new_attributes[:expiration].to_s))
+        expect(rental.prettyTime).to eq(Time.at(new_attributes[:expiration]/1000))
       end
 
       it "renders json of the rental" do


### PR DESCRIPTION
Rentals were stored as Time whereas Members were stored as Integers.  This was causing a bug where, when renewing rentals, expiration times were always being set from the day of renewal rather than the day of expiration.  
Rentals and Members will now both be stored as Integers, using a common Module to manage formatting and updating expiration times.

I manually confirmed the expiration date of all Rentals in production that could have been affected by this bug.