### PR TITLE
Deploy patches

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -41,7 +41,10 @@ class Admin::MembersController < AdminController
 
   def notify_renewal(init)
     final = @member.expirationTime
-    if (Time.at(final / 1000) - Time.at((init || 0) / 1000) > 1.day)
+    # Check if adding expiration too
+    if final &&
+        (init.nil? || 
+        (Time.at(final / 1000) - Time.at((init || 0) / 1000) > 1.day))
       time = @member.pretty_time.strftime("%m/%d/%Y")
       @messages.push("#{@member.fullname} renewed. Now expiring #{time}")
     end

--- a/app/controllers/admin/rentals_controller.rb
+++ b/app/controllers/admin/rentals_controller.rb
@@ -38,7 +38,10 @@ class Admin::RentalsController < AdminController
 
   def notify_renewal(init)
     final = @rental.get_expiration
-    if (Time.at(final / 1000) - Time.at((init || 0) / 1000) > 1.day)
+    # Check if adding expiration too
+    if final &&
+        (init.nil? || 
+        (Time.at(final / 1000) - Time.at((init || 0) / 1000) > 1.day))
       core_msg = "#{@rental.member ? "#{@rental.member.fullname}'s rental of " : ""} Locker/Plot # #{@rental.number}"
       time = @rental.pretty_time.strftime("%m/%d/%Y")
       @messages.push("#{core_msg} renewed.  Now expiring #{time}")

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -8,9 +8,10 @@ class MembersController < AuthenticationController
       if is_admin? && (params[:currentMembers].nil? || params[:currentMembers].empty?)
         search = Mongoid::Criteria.new(Member)
       else
+        # Include unset or expired within grace period
         search = Member.where({
           :$or => [
-            { :expirationTime.gte => (Time.now.strftime('%s').to_i * 1000) },
+            { :expirationTime.gte => ((Time.now + 3.days).strftime('%s').to_i * 1000) },
             {  expirationTime: nil }
           ]
         })

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -8,7 +8,12 @@ class MembersController < AuthenticationController
       if is_admin? && (params[:currentMembers].nil? || params[:currentMembers].empty?)
         search = Mongoid::Criteria.new(Member)
       else
-        search = Member.where(:expirationTime => { '$gt' => (Time.now.strftime('%s').to_i * 1000) })
+        search = Member.where({
+          :$or => [
+            { :expirationTime.gte => (Time.now.strftime('%s').to_i * 1000) },
+            {  expirationTime: nil }
+          ]
+        })
       end
       @members = query_params[:search].nil? || query_params[:search].empty? ? search.all : Member.rough_search_members(query_params[:search], search)
       @members = query_resource(@members)

--- a/app/javascript/src/ui/member/MemberForm.tsx
+++ b/app/javascript/src/ui/member/MemberForm.tsx
@@ -104,20 +104,21 @@ class MemberForm extends React.Component<OwnProps, State> {
       </Grid>
       {isAdmin && (
         <>
-          <Grid item xs={12}>
-            <TextField
-              fullWidth
-              required
-              value={toDatePicker(member.expirationTime)}
-              label={fields.expirationTime.label}
-              name={fields.expirationTime.name}
-              placeholder={fields.expirationTime.placeholder}
-              type="date"
-              InputLabelProps={{
-                shrink: true,
-              }}
-            />
-          </Grid>
+          {fields.expirationTime && ( // Dont display expiration for creation
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                value={toDatePicker(member.expirationTime)}
+                label={fields.expirationTime.label}
+                name={fields.expirationTime.name}
+                placeholder={fields.expirationTime.placeholder}
+                type="date"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            </Grid>
+          )}
           <Grid item xs={12}>
             <FormLabel component="legend">{fields.status.label}</FormLabel>
             <Select

--- a/app/javascript/src/ui/member/constants.ts
+++ b/app/javascript/src/ui/member/constants.ts
@@ -48,13 +48,14 @@ export const fields = (admin: boolean, member?: Partial<MemberDetails>): FormFie
       name: `${formPrefix}-groupName`,
       placeholder: "Select one",
     },
-    expirationTime: {
-      label: "Expiration Date",
-      name: `${formPrefix}-expirationTime`,
-      placeholder: "Membership Expiration",
-      validate: (val) => !!val,
-      transform: (val) => dateToTime(val),
-      error: "Invalid expiration"
+    ...member && member.id && {
+      expirationTime: {
+        label: "Expiration Date",
+        name: `${formPrefix}-expirationTime`,
+        placeholder: "Membership Expiration",
+        transform: (val) => dateToTime(val),
+        error: "Invalid expiration"
+      },
     },
     role: {
       label: "Role",

--- a/app/javascript/src/ui/rentals/RentalForm.tsx
+++ b/app/javascript/src/ui/rentals/RentalForm.tsx
@@ -122,20 +122,21 @@ class RentalForm extends React.Component<OwnProps, State> {
               placeholder={fields.description.placeholder}
             />
           </Grid>
-          <Grid item xs={12}>
-            <TextField
-              fullWidth
-              required
-              value={toDatePicker(rental.expiration)}
-              label={fields.expiration.label}
-              name={fields.expiration.name}
-              placeholder={fields.expiration.placeholder}
-              type="date"
-              InputLabelProps={{
-                shrink: true,
-              }}
-            />
-          </Grid>
+          {rental && rental.id && (
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                value={toDatePicker(rental.expiration)}
+                label={fields.expiration.label}
+                name={fields.expiration.name}
+                placeholder={fields.expiration.placeholder}
+                type="date"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            </Grid>
+          )}
           <Grid item xs={12}>
             <FormLabel component="legend">{fields.memberId.label}</FormLabel>
             <AsyncSelectFixed

--- a/app/javascript/src/ui/rentals/RentalsList.tsx
+++ b/app/javascript/src/ui/rentals/RentalsList.tsx
@@ -71,7 +71,7 @@ class RentalsList extends React.Component<Props, State> {
     {
       id: "expiration",
       label: "Expiration Date",
-      cell: (row: Rental) => timeToDate(row.expiration),
+      cell: (row: Rental) => row.expiration ? timeToDate(row.expiration) : "N/A",
       defaultSortDirection: SortDirection.Desc,
     },
     ...this.props.admin ? [{

--- a/app/javascript/src/ui/rentals/constants.ts
+++ b/app/javascript/src/ui/rentals/constants.ts
@@ -64,7 +64,6 @@ export const fields = {
     name: `${formPrefix}-expiration`,
     placeholder: "Select an expiration date",
     transform: (val: string) => dateToTime(val),
-    validate: (val: string) => !!val,
     error: "Expiration date required"
   },
   memberId: {

--- a/app/models/earned_membership.rb
+++ b/app/models/earned_membership.rb
@@ -16,7 +16,7 @@ class EarnedMembership
   validate :existing_subscription
   validate :requirements_exist
 
-  after_create :set_member_expiration
+  after_save :set_member_expiration
 
   def outstanding_requirements
     requirements.select do |requirement|

--- a/tests/functional/suites/members.spec.ts
+++ b/tests/functional/suites/members.spec.ts
@@ -67,7 +67,6 @@ describe("Members page", () => {
       await utils.clickElement(memberPo.memberForm.submit);
       await utils.assertInputError(memberPo.memberForm.firstname);
       await utils.assertInputError(memberPo.memberForm.lastname);
-      await utils.assertInputError(memberPo.memberForm.expiration);
       await utils.assertInputError(memberPo.memberForm.email);
       await utils.assertInputError(memberPo.memberForm.contract);
       await utils.clickElement(memberPo.memberForm.contract);
@@ -79,8 +78,6 @@ describe("Members page", () => {
       await utils.fillInput(memberPo.memberForm.email, "");
       await utils.fillInput(memberPo.memberForm.lastname, newMember.lastname);
       await utils.assertNoInputError(memberPo.memberForm.lastname);
-      await utils.inputTime(memberPo.memberForm.expiration, newMember.expirationTime);
-      await utils.assertNoInputError(memberPo.memberForm.expiration);
 
       await utils.clickElement(memberPo.memberForm.submit);
       await utils.assertInputError(memberPo.memberForm.email);

--- a/tests/functional/suites/rentals.spec.ts
+++ b/tests/functional/suites/rentals.spec.ts
@@ -50,7 +50,6 @@ describe("Rentals", () => {
         await utils.waitForVisible(rentalsPO.rentalForm.submit);
         await utils.fillInput(rentalsPO.rentalForm.number, initRental.number);
         await utils.fillInput(rentalsPO.rentalForm.description, initRental.description);
-        await utils.inputTime(rentalsPO.rentalForm.expiration, initRental.expiration);
 
         await mock(mockRequests.rentals.post.ok(initRental));
         await mock(mockRequests.rentals.get.ok([initRental], undefined, true));

--- a/tests/functional/suites/rentals.spec.ts
+++ b/tests/functional/suites/rentals.spec.ts
@@ -154,7 +154,6 @@ describe("Rentals", () => {
         expect(await utils.getElementText(rentalsPO.rentalForm.member)).toEqual(`${basicUser.firstname} ${basicUser.lastname}`);
         await utils.fillInput(rentalsPO.rentalForm.number, initRental.number);
         await utils.fillInput(rentalsPO.rentalForm.description, initRental.description);
-        await utils.inputTime(rentalsPO.rentalForm.expiration, initRental.expiration);
 
         await mock(mockRequests.rentals.post.ok(initRental));
         await mock(mockRequests.rentals.get.ok([initRental], undefined, true));


### PR DESCRIPTION
1. EMs will update expirations correctly on creation
2. Expirations no longer part of rental / member creation. Still possible to edit directly as escape hatch for renewal system
3. Return expired members within grace period when requesting current members to reduce confusion when renewing a recently expired member
4. Return members w/o an expiration when requesting current members to reduce confusion when manually creating a member
5. Provide more logs when db backup fails and point to #interface-logs channel